### PR TITLE
Fixed support for running on 32 bit python

### DIFF
--- a/pymot.py
+++ b/pymot.py
@@ -21,7 +21,7 @@ class MOTEvaluation:
         self.overlap_threshold_ = 0.2
         """Bounding box overlap threshold"""
     
-        self.munkres_inf_ = 5.0*(10**17)
+        self.munkres_inf_ = sys.maxsize
         """Not quite infinite number for Munkres algorithm"""
     
         self.sync_delta_ = 0.001


### PR DESCRIPTION
Hi. This fix allows the munkres calculations to work on 32bit systems. Credit should go to Mika Fischer who responded to my emails on the subject and got me going. 

See below for the logging around the issue:

[TestJSON.zip](https://github.com/Videmo/pymot/files/138359/TestJSON.zip)
zvision:testTools rj$ ./pymot.sh -a 1.json -b 2.json -v zzz.json 
INFO:**main**:
INFO:**main**:Timestamp: 0.4
INFO:**main**:DIFF
INFO:**main**:DIFF Time 0.40
INFO:**main**:DIFF Mappings:
INFO:**main**:GTs:
INFO:**main**:(id, x,y,w,h) = (4, 1.0, 1.0, 10.0, 10.0, non-DCO)
INFO:**main**:(id, x,y,w,h) = (5, 100.0, 100.0, 10.0, 10.0, non-DCO)
INFO:**main**:Hypos:
INFO:**main**:(id, x,y,w,h) = (223, 226.0, 168.0, 13.0, 54.0, non-DCO)
INFO:**main**:
INFO:**main**:STEP 1: KEEP CORRESPONDENCE
INFO:**main**:
INFO:**main**:STEP 2: FIND CORRESPONDENCE
DEBUG:**main**:[[5e+17], [5e+17]]
computing munkres...2
^CTraceback (most recent call last):
  File "pymot/pymot.py", line 597, in <module>
    evaluator.evaluate()
  File "pymot/pymot.py", line 90, in evaluate
    self.evaluateFrame(frame)
  File "pymot/pymot.py", line 212, in evaluateFrame
    indices = m.compute(munkres_matrix)
  File "/Users/rj/DevClean/DJI/SentryD/testTools/munkres/munkres.py", line 412, in compute
    step = func()
  File "/Users/rj/DevClean/DJI/SentryD/testTools/munkres/munkres.py", line 501, in __step4
    done = False
KeyboardInterrupt
zvision:testTools rj$ 

My two json files are attached for your reference. I am running the latest copies of pymot and munkres (from https://github.com/bmc/munkres ).

If I leave only one GT annotation, or add a second hypothesis everything works as expected. 
